### PR TITLE
NyanoCombat 2, Part 3: Stamina Traits

### DIFF
--- a/Content.Shared/Traits/Assorted/Components/StaminaCritModifierComponent.cs
+++ b/Content.Shared/Traits/Assorted/Components/StaminaCritModifierComponent.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Traits.Assorted.Components;
+
+/// <summary>
+///     This is used for any trait that modifies stamina CritThreshold
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class StaminaCritModifierComponent : Component
+{
+    /// <summary>
+    ///     The amount that an entity's stamina critical threshold will be incremented by.
+    /// </summary>
+    [DataField]
+    public int CritThresholdModifier { get; private set; } = 0;
+}

--- a/Content.Shared/Traits/Assorted/Systems/TraitStatModifierSystem.cs
+++ b/Content.Shared/Traits/Assorted/Systems/TraitStatModifierSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Traits.Assorted.Components;
 using Content.Shared.Weapons.Melee.Events;
+using Content.Shared.Damage.Components;
 
 namespace Content.Shared.Traits.Assorted.Systems;
 
@@ -15,6 +16,7 @@ public sealed partial class TraitStatModifierSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<CritModifierComponent, ComponentStartup>(OnCritStartup);
         SubscribeLocalEvent<DeadModifierComponent, ComponentStartup>(OnDeadStartup);
+        SubscribeLocalEvent<StaminaCritModifierComponent, ComponentStartup>(OnStaminaCritStartup);
         SubscribeLocalEvent<AdrenalineComponent, GetMeleeDamageEvent>(OnAdrenalineGetDamage);
         SubscribeLocalEvent<PainToleranceComponent, GetMeleeDamageEvent>(OnPainToleranceGetDamage);
     }
@@ -37,6 +39,14 @@ public sealed partial class TraitStatModifierSystem : EntitySystem
         var deadThreshold = _threshold.GetThresholdForState(uid, Mobs.MobState.Dead, threshold);
         if (deadThreshold != 0)
             _threshold.SetMobStateThreshold(uid, deadThreshold + component.DeadThresholdModifier, Mobs.MobState.Dead);
+    }
+
+    private void OnStaminaCritStartup(EntityUid uid, StaminaCritModifierComponent component, ComponentStartup args)
+    {
+        if (!TryComp<StaminaComponent>(uid, out var stamina))
+            return;
+
+        stamina.CritThreshold += component.CritThresholdModifier;
     }
 
     private void OnAdrenalineGetDamage(EntityUid uid, AdrenalineComponent component, ref GetMeleeDamageEvent args)

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -103,3 +103,13 @@ trait-description-MartialArtist =
     You have received formal training in unarmed combat, whether with Fists, Feet, or Claws.
     Your unarmed melee attacks have a small range increase, and deal 50% more damage.
     This does not apply to any form of armed melee, only the weapons you were naturally born with.
+
+trait-name-Vigor = Vigor
+trait-description-Vigor =
+    Whether by pure determination, fitness, or bionic augmentations, your endurance is enhanced.
+    Your stamina is increased by 15 points.
+
+trait-name-Lethargy = Lethargy
+trait-description-Lethargy =
+    You become tired faster than others, making you more vulnerable to exhaustion and fatigue.
+    Your stamina is decreased by 20 points.

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -71,6 +71,42 @@
       critThresholdModifier: -10
 
 - type: trait
+  id: Vigor
+  category: Physical
+  points: -2
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Lethargy
+  components:
+    - type: StaminaCritModifier
+      critThresholdModifier: 15
+
+- type: trait
+  id: Lethargy
+  category: Physical
+  points: 1
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Vigor
+  components:
+    - type: StaminaCritModifier
+      critThresholdModifier: -20
+
+- type: trait
   id: HighAdrenaline
   category: Physical
   points: -2


### PR DESCRIPTION
# Description

Adds two new traits to NyanoCombat 2, Part 3 (https://github.com/Simple-Station/Einstein-Engines/pull/607) that modify stamina.

- **Vigor**: Increases stamina by 15 points
- **Lethargy**: Decreases stamina by 20 points

## Media

![image](https://github.com/user-attachments/assets/504dcb2b-5e51-4e06-86f3-c0a204696481)
![image](https://github.com/user-attachments/assets/f4983223-f52d-4113-80b7-cff3bc6ff74f)