### PR TITLE
NyanoCombat 2, Part 3: Tweak Stamina Traits

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -107,9 +107,9 @@ trait-description-MartialArtist =
 trait-name-Vigor = Vigor
 trait-description-Vigor =
     Whether by pure determination, fitness, or bionic augmentations, your endurance is enhanced.
-    Your stamina is increased by 15 points.
+    Your stamina is increased by 10 points.
 
 trait-name-Lethargy = Lethargy
 trait-description-Lethargy =
     You become tired faster than others, making you more vulnerable to exhaustion and fatigue.
-    Your stamina is decreased by 20 points.
+    Your stamina is decreased by 15 points.

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -80,6 +80,10 @@
       jobs:
         - Borg
         - MedicalBorg
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Oni
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
@@ -98,6 +102,10 @@
       jobs:
         - Borg
         - MedicalBorg
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Felinid
     - !type:CharacterTraitRequirement
       inverted: true
       traits:

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -90,7 +90,7 @@
         - Lethargy
   components:
     - type: StaminaCritModifier
-      critThresholdModifier: 15
+      critThresholdModifier: 10
 
 - type: trait
   id: Lethargy
@@ -112,7 +112,7 @@
         - Vigor
   components:
     - type: StaminaCritModifier
-      critThresholdModifier: -20
+      critThresholdModifier: -15
 
 - type: trait
   id: HighAdrenaline


### PR DESCRIPTION
# Description

Adjust stamina modifiers for Vigor and Lethargy.

- **Vigor**: +15 -> +10 stamina
- **Lethargy**: -20 -> -15 stamina

Prevent Onis from selecting Vigor, and Felinids from selecting Lethargy, because their species has an equivalent to these traits.