### PR TITLE
Mood System Bug Fixes & Slight Refactor

### DIFF
--- a/Resources/Prototypes/Mood/generic_negativeEffects.yml
+++ b/Resources/Prototypes/Mood/generic_negativeEffects.yml
@@ -49,3 +49,8 @@
   id: TraitSaturnine
   description: "Everything kind of sucks. I hate this job. "
   moodChange: -20
+
+- type: moodEffect
+  id: Dead
+  description: "You are dead."
+  moodChange: -1000


### PR DESCRIPTION
# Description

Fixes a bug surrounding the neutral threshold (50) being added twice in `SetMood`, resulting in 100 mood for everyone.

Fixes the `NetMoodComponent` field `CurrentMoodLevel` not being synced properly with `MoodComponent`.

This also refactors `MoodSystem` to centralize mood calculations to `RefreshMood` and `SetMood`.

For consistency reasons and due to the above refactor, death is now a moodlet that gets added upon death, and removed upon revival. Only `RefreshMood` should ever get to call `SetMood`.

I have more ideas on refactoring `MoodSystem` in separate PRs.

This PR is for this PR: https://github.com/Simple-Station/Einstein-Engines/pull/620